### PR TITLE
Add option to disable kube-vip

### DIFF
--- a/.config.sample.env
+++ b/.config.sample.env
@@ -36,6 +36,11 @@ export BOOTSTRAP_METALLB_TRAEFIK_ADDR=""
 # e.g. age15uzrw396e67z9wdzsxzdk7ka0g2gr3l460e0slaea563zll3hdfqwqxdta
 export BOOTSTRAP_AGE_PUBLIC_KEY=""
 
+
+# Enable / Disable kube-vip
+# If this is set to false (e.g. on a cluster with a single-node control plane), do not install kube-vip.
+# BOOTSTRAP_KUBE_VIP_ADDR needs to be set to the IP the API Server is reachable under
+export BOOTSTRAP_KUBE_VIP_ENABLED="true"
 # The IP Address to use with KubeVIP
 # Pick a unused IP that is on the same network as your nodes
 # and outside the ${BOOTSTRAP_METALLB_LB_RANGE} range

--- a/configure
+++ b/configure
@@ -45,8 +45,10 @@ main() {
             > "${PROJECT_DIR}/cluster/config/cluster-settings.yaml"
         envsubst < "${PROJECT_DIR}/tmpl/cluster/flux-cluster.yaml" \
             > "${PROJECT_DIR}/cluster/flux/flux-system/flux-cluster.yaml"
-        envsubst < "${PROJECT_DIR}/tmpl/cluster/kube-vip-daemonset.yaml" \
-            > "${PROJECT_DIR}/cluster/apps/kube-system/kube-vip/daemon-set.yaml"
+        if [[ "${BOOTSTRAP_KUBE_VIP_ENABLED}" == "true" ]]; then
+            envsubst < "${PROJECT_DIR}/tmpl/cluster/kube-vip-daemonset.yaml" \
+                > "${PROJECT_DIR}/cluster/apps/kube-system/kube-vip/daemon-set.yaml"
+	fi
         # generate cluster secrets
         envsubst < "${PROJECT_DIR}/tmpl/cluster/cluster-secrets.sops.yaml" \
             > "${PROJECT_DIR}/cluster/config/cluster-secrets.sops.yaml"
@@ -353,7 +355,7 @@ verify_ansible_hosts() {
         _has_envar "${node_control}"
         _has_optional_envar "${node_hostname}"
 
-        if [[ "${!node_addr}" == "${BOOTSTRAP_KUBE_VIP_ADDR}" ]]; then
+        if [[ "${!node_addr}" == "${BOOTSTRAP_KUBE_VIP_ADDR}" && "${BOOTSTRAP_KUBE_VIP_ENABLED}" == "true" ]]; then
             _log "ERROR" "The kube-vip IP '${BOOTSTRAP_KUBE_VIP_ADDR}' should not be the same as the IP for node '${!node_addr}'"
             exit 1
         fi


### PR DESCRIPTION
**Description of the change**

Add an option to disable kube-vip

**Benefits**

Reduced resource usage on clusters that don't have a HA control plane.

**Possible drawbacks**



**Applicable issues**

**Additional information**

This mainly allows to not disable kube-vip because of limitations when exposing a kubernetes api endpoint via wireguard (layer3 tunnel, so ARP won't work there).