### PR TITLE
Added information about kubeconfig for newcomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ In order to use Terraform and `cert-manager` with the Cloudflare DNS challenge y
 
 📍 Here we will be running a Ansible Playbook to install [k3s](https://k3s.io/) with [this](https://galaxy.ansible.com/xanmanning/k3s) wonderful k3s Ansible galaxy role. After completion, Ansible will drop a `kubeconfig` in `./provision/kubeconfig` for use with interacting with your cluster with `kubectl`.
 -Note: kubectl defaults to $HOME/.kube/config to find a kubeconfig and then references $KUBECONFIG otherwise if it can't find it.
---You must either copy kubeconfig into $HOME/.kube/config OR use [direnv](https://github.com/direnv/direnv) to source this project's .envrc file which sets $KUBECONFIG
+--You must either copy kubeconfig into $HOME/.kube/config OR use the recommended [direnv](https://github.com/direnv/direnv) to source this project's .envrc file which sets $KUBECONFIG
 
 ☢️ If you run into problems, you can run `task ansible:nuke` to destroy the k3s cluster and start over.
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ In order to use Terraform and `cert-manager` with the Cloudflare DNS challenge y
 ### ⛵ Installing k3s with Ansible
 
 📍 Here we will be running a Ansible Playbook to install [k3s](https://k3s.io/) with [this](https://galaxy.ansible.com/xanmanning/k3s) wonderful k3s Ansible galaxy role. After completion, Ansible will drop a `kubeconfig` in `./provision/kubeconfig` for use with interacting with your cluster with `kubectl`.
+-Note: kubectl defaults to $HOME/.kube/config to find a kubeconfig and then references $KUBECONFIG otherwise if it can't find it.
+--You must either copy kubeconfig into $HOME/.kube/config OR use [direnv](https://github.com/direnv/direnv) to source this project's .envrc file which sets $KUBECONFIG
 
 ☢️ If you run into problems, you can run `task ansible:nuke` to destroy the k3s cluster and start over.
 


### PR DESCRIPTION
I personally spent a handful of hours debugging a "connection to localhost:8080 refused". It turned out that kubectl was not loading the populated kubeconfig from the guide due to an empty $HOME/.kube/config and $KUBECONFIG.

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
